### PR TITLE
Comments regarding latest bugfix and program version bump

### DIFF
--- a/append.asm
+++ b/append.asm
@@ -28,7 +28,8 @@
 ;				Bug: Now it _really_ frees the environment
 ; 06-01-23  casino_e@terra.es   Add version string
 ;
-%define	VERSION	"5.0.0.6"
+
+%define	VERSION	"5.0.0.7"
 
 %ifdef NEW_NASM
 	cpu	8086

--- a/history.txt
+++ b/history.txt
@@ -43,3 +43,9 @@
 	* Bugfix: Append now recognises itself when called with a prepended
 	  path, like MS APPEND (thanks to Blair Campbell for the report and
           test case)
+          
+02-18-24 Version 0.7
+
+	* Bigfix: Fix to function call result check that would prevent FCB 
+	  calls from working properly and limit usage to file handle I/O. 
+	  

--- a/int21.asm
+++ b/int21.asm
@@ -22,6 +22,7 @@
 ; 04-06-15  casino_e@terra.es	Save some bytes by re-using buffers. (Suggested
 ;				by Eric)
 ; 04-06-17  casino_e@terra.es	Move tempDTA to PSP
+; 02-18-24  tsupplis            Open file, Get file size using FCB logic fix
 ;
 
 old_int21	dd	0		; Original INT 21 handler


### PR DESCRIPTION
Code and history comments regarding the fix from tsupplis.

Plus, a version bump to 0.7 to prevent confusion when included in the next Interim Build of FreeDOS.

